### PR TITLE
Revert "Build(deps): Bump github.com/openmfp/golang-commons from 0.37…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.3-bullseye as builder
+FROM golang:1.22.2-bullseye as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/openmfp/extension-content-operator
 
-go 1.22.3
+go 1.22.0
 
 require (
 	github.com/jarcoal/httpmock v1.3.1
-	github.com/openmfp/golang-commons v0.39.0
+	github.com/openmfp/golang-commons v0.37.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/onsi/ginkgo/v2 v2.17.2 h1:7eMhcy3GimbsA3hEnVKdw/PQM9XN9krpKVXsZdph0/g
 github.com/onsi/ginkgo/v2 v2.17.2/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
-github.com/openmfp/golang-commons v0.39.0 h1:3hmbRlLgg2jZ0MmtWu0bsg1a+EsAqYgwRrttG4tezf0=
-github.com/openmfp/golang-commons v0.39.0/go.mod h1:V+IVBwzCifLwW6ygzWbwrBdy6ztyUEkPfBPA+YJNK/s=
+github.com/openmfp/golang-commons v0.37.0 h1:SlDXDFXFa2wuo8eo33LzGlTdOVu/PTM7zcZ80r/9HCc=
+github.com/openmfp/golang-commons v0.37.0/go.mod h1:FOaKSqVKf+qPv0myrVtpyoSeBinYuoeIwD1hYMNiGuA=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
….0 to 0.39.0 (#41)"

This reverts commit 4a841122d906004f682c417258c7f27cf2b00126.