### PR TITLE
fix (test): additional testing for internalUrl

### DIFF
--- a/internal/controller/contentconfiguration_controller_test.go
+++ b/internal/controller/contentconfiguration_controller_test.go
@@ -246,7 +246,7 @@ func (suite *ContentConfigurationTestSuite) TestContentConfigurationCreationInte
 			Namespace: defaultNamespace,
 		},
 		Spec: cachev1alpha1.ContentConfigurationSpec{
-			RemoteConfiguration: cachev1alpha1.RemoteConfiguration{
+			RemoteConfiguration: &cachev1alpha1.RemoteConfiguration{
 				ContentType: "json",
 				InternalUrl: internalURL,
 				URL:         remoteURL,
@@ -258,7 +258,7 @@ func (suite *ContentConfigurationTestSuite) TestContentConfigurationCreationInte
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder(
-		"GET", remoteURL, httpmock.NewStringResponder(200, validation_test.GetJSONFixture(validation_test.GetValidJSON())),
+		"GET", remoteURL, httpmock.NewStringResponder(200, validation_test.GetValidJSON()),
 	)
 
 	// When
@@ -281,7 +281,7 @@ func (suite *ContentConfigurationTestSuite) TestContentConfigurationCreationInte
 	// Update InternalURL and make it valid by mocking
 	// Given
 	httpmock.RegisterResponder(
-		"GET", internalURL, httpmock.NewStringResponder(200, validation_test.GetJSONFixture(validation_test.GetValidJSON())),
+		"GET", internalURL, httpmock.NewStringResponder(200, validation_test.GetValidJSON()),
 	)
 
 	// When
@@ -299,8 +299,8 @@ func (suite *ContentConfigurationTestSuite) TestContentConfigurationCreationInte
 				Namespace: contentConfiguration.Namespace,
 			}, &updatedInstance)
 
-			return err == nil &&
-				updatedInstance.Status.ConfigurationResult == validation_test.GetJSONFixture(validation_test.GetValidJSON())
+			equal, cErr := commonTesting.CompareJSON(validation_test.GetValidJSON(), updatedInstance.Status.ConfigurationResult)
+			return err == nil && cErr == nil && equal
 		},
 		defaultTestTimeout, defaultTickInterval,
 	)

--- a/pkg/subroutines/contentconfiguration.go
+++ b/pkg/subroutines/contentconfiguration.go
@@ -158,7 +158,7 @@ func (r *ContentConfigurationSubroutine) getRemoteConfig(url string, log *logger
 
 	resp, err := r.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %v", err), true
+		return nil, fmt.Errorf("request failed: %v", err)
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {


### PR DESCRIPTION
### Description

If the `internalUrl` is initially unreachable, the operator didn't retry leading to resources not being valid even if the address eventually becomes available.