### PR TITLE
fix(validation): change Component field to pointer in VisibleForEntityContext

### DIFF
--- a/pkg/validation/model.go
+++ b/pkg/validation/model.go
@@ -167,8 +167,8 @@ type Url struct {
 }
 
 type VisibleForEntityContext struct {
-	Project   Project   `json:"project,omitempty" yaml:"project,omitempty"`
-	Component Component `json:"component,omitempty" yaml:"component,omitempty"`
+	Project   Project    `json:"project,omitempty" yaml:"project,omitempty"`
+	Component *Component `json:"component,omitempty" yaml:"component,omitempty"`
 }
 
 type Type struct {


### PR DESCRIPTION
The `component` field is being added because it is part of the `VisibleForEntityContext` struct in the model.go file, and its `omitempty` tag only prevents it from being included in the JSON output if it is `nil` or empty. However, since `component` is a struct (not a pointer), it is always initialized with its zero value (an empty `Component` struct), which is not considered "empty" by the `omitempty` tag.
